### PR TITLE
Feat/#47

### DIFF
--- a/src/configs/typeorm.config.ts
+++ b/src/configs/typeorm.config.ts
@@ -11,5 +11,5 @@ export const typeORMConfig: TypeOrmModuleOptions = {
   password: process.env.DB_PASSWORD,
   database: process.env.DB_NAME,
   entities: [__dirname + '/../**/*entity.{js,ts}', 'dist/**/**entity.{js,ts}'],
-  synchronize: false,
+  synchronize: true,
 };

--- a/src/member/application/member.service.ts
+++ b/src/member/application/member.service.ts
@@ -20,6 +20,7 @@ import { StarService } from '../../star/application/star.service';
 import { StarSummaryResponseDto } from '../presentation/dto/star-summary-response.dto';
 import { StarResponseDto } from '../../star/presentation/dto/star-response.dto';
 import { LogDataService } from 'src/rank/application/log-data.service';
+import { Filter } from 'src/rank/domain/filter.enum';
 
 @Injectable()
 export class MemberService {
@@ -60,12 +61,17 @@ export class MemberService {
     return new StarSummaryResponseDto(followSummary, followerSummary);
   }
 
-  public async getMemberSummary(filer: string, id: number): Promise<MemberSummaryResponseDto> {
+  public async getMemberSummary(id: number): Promise<MemberSummaryResponseDto> {
     const member = await this.memberRepository.findOneOrThrow(id);
 
     const grade = await this.getGrade(id);
 
-    const rank = await this.logDataService.getRankWithNeighbors(filer, id);
+    const rank = await Promise.all(Object.values(Filter).map(async (filter) => {
+      const ranking = await this.logDataService.getRankWithNeighbors(filter, id);
+      const rank = {};
+      rank[filter] = ranking;
+      return rank;
+    }));
     
     const githubStat = await this.getGithubInfoById(id);
 

--- a/src/member/application/member.service.ts
+++ b/src/member/application/member.service.ts
@@ -19,6 +19,7 @@ import { ProfileService } from './profile.service';
 import { StarService } from '../../star/application/star.service';
 import { StarSummaryResponseDto } from '../presentation/dto/star-summary-response.dto';
 import { StarResponseDto } from '../../star/presentation/dto/star-response.dto';
+import { LogDataService } from 'src/rank/application/log-data.service';
 
 @Injectable()
 export class MemberService {
@@ -34,6 +35,7 @@ export class MemberService {
     private readonly blogService: BlogService,
     private readonly profileService: ProfileService,
     private readonly starService: StarService,
+    private readonly logDataService: LogDataService,
     private readonly githubClient: GithubClient,
     private readonly crawler: Crawler,
   ) {}
@@ -58,11 +60,13 @@ export class MemberService {
     return new StarSummaryResponseDto(followSummary, followerSummary);
   }
 
-  public async getMemberSummary(id: number): Promise<MemberSummaryResponseDto> {
+  public async getMemberSummary(filer: string, id: number): Promise<MemberSummaryResponseDto> {
     const member = await this.memberRepository.findOneOrThrow(id);
 
     const grade = await this.getGrade(id);
 
+    const rank = await this.logDataService.getRankWithNeighbors(filer, id);
+    
     const githubStat = await this.getGithubInfoById(id);
 
     const contributions = await this.getGithubContributionsInRepository(id);

--- a/src/member/application/member.service.ts
+++ b/src/member/application/member.service.ts
@@ -86,6 +86,7 @@ export class MemberService {
       blogStat,
       starSummary,
       profile,
+      rank
     );
   }
 

--- a/src/member/member.module.ts
+++ b/src/member/member.module.ts
@@ -14,6 +14,7 @@ import { LogDataRepository } from '../rank/repository/log-data.repository';
 import { DataLogTypeRepository } from '../rank/repository/data-log-type.repository';
 import { StarRepository } from '../star/repository/star.repository';
 import { StarModule } from '../star/star.module';
+import { LogDataService } from 'src/rank/application/log-data.service';
 
 @Module({
   imports: [
@@ -32,6 +33,7 @@ import { StarModule } from '../star/star.module';
     MemberService,
     ProfileService,
     BlogService,
+    LogDataService,
     GithubClient,
     Crawler,
   ],

--- a/src/member/presentation/dto/member-summary-response.dto.ts
+++ b/src/member/presentation/dto/member-summary-response.dto.ts
@@ -8,6 +8,7 @@ import { GradeDto } from '../../application/dto/grade.dto';
 import { GithubContribution } from '../../application/dto/github-contribution-response.dto';
 import { ProfileResponseDto } from './profile-response.dto';
 import { StarSummaryResponseDto } from './star-summary-response.dto';
+import { RankDto } from '../../../rank/application/dto/rank.dto';
 
 export class MemberSummaryResponseDto {
   @ApiProperty()
@@ -37,7 +38,7 @@ export class MemberSummaryResponseDto {
   @ApiProperty()
   readonly githubStat?: MemberGithubResponseDto;
 
-  @ApiProperty()
+  @ApiProperty({ type: [GithubContribution] })
   readonly contributions?: GithubContribution[];
 
   @ApiProperty()
@@ -49,6 +50,11 @@ export class MemberSummaryResponseDto {
   @ApiProperty()
   readonly profile: ProfileResponseDto;
 
+  @ApiProperty({ type: [RankDto] })
+  readonly rank: RankDto[];
+
+  
+
   constructor(
     member: Member,
     grade: GradeDto,
@@ -57,6 +63,7 @@ export class MemberSummaryResponseDto {
     blogStat?: BlogResponseDto,
     star?: StarSummaryResponseDto,
     profile?: ProfileResponseDto,
+    rank?: RankDto[]
   ) {
     this.id = member.id;
     this.name = member.name;
@@ -71,5 +78,6 @@ export class MemberSummaryResponseDto {
     this.blogStat = blogStat;
     this.star = star;
     this.profile = profile;
+    this.rank = rank;
   }
 }

--- a/src/member/presentation/dto/member-summary-response.dto.ts
+++ b/src/member/presentation/dto/member-summary-response.dto.ts
@@ -8,7 +8,7 @@ import { GradeDto } from '../../application/dto/grade.dto';
 import { GithubContribution } from '../../application/dto/github-contribution-response.dto';
 import { ProfileResponseDto } from './profile-response.dto';
 import { StarSummaryResponseDto } from './star-summary-response.dto';
-import { RankDto } from '../../../rank/application/dto/rank.dto';
+import { RankDto, userRankDto } from '../../../rank/application/dto/rank.dto';
 
 export class MemberSummaryResponseDto {
   @ApiProperty()
@@ -50,8 +50,8 @@ export class MemberSummaryResponseDto {
   @ApiProperty()
   readonly profile: ProfileResponseDto;
 
-  @ApiProperty({ type: [RankDto] })
-  readonly rank: RankDto[];
+  @ApiProperty()
+  readonly rank: any;
 
   
 
@@ -63,7 +63,7 @@ export class MemberSummaryResponseDto {
     blogStat?: BlogResponseDto,
     star?: StarSummaryResponseDto,
     profile?: ProfileResponseDto,
-    rank?: RankDto[]
+    rank?: any
   ) {
     this.id = member.id;
     this.name = member.name;

--- a/src/member/presentation/dto/member-summary-response.dto.ts
+++ b/src/member/presentation/dto/member-summary-response.dto.ts
@@ -8,7 +8,6 @@ import { GradeDto } from '../../application/dto/grade.dto';
 import { GithubContribution } from '../../application/dto/github-contribution-response.dto';
 import { ProfileResponseDto } from './profile-response.dto';
 import { StarSummaryResponseDto } from './star-summary-response.dto';
-import { RankDto, userRankDto } from '../../../rank/application/dto/rank.dto';
 
 export class MemberSummaryResponseDto {
   @ApiProperty()

--- a/src/member/presentation/member.controller.ts
+++ b/src/member/presentation/member.controller.ts
@@ -33,6 +33,7 @@ import { ProfileResponseDto } from './dto/profile-response.dto';
 import { GithubContribution } from '../application/dto/github-contribution-response.dto';
 import { MemberGithubResponseDto } from './dto/member-github-response.dto';
 import { MemberSummaryResponseDto } from './dto/member-summary-response.dto';
+import { Filter } from 'src/rank/domain/filter.enum';
 
 @Controller('member')
 @ApiTags('Member')
@@ -51,13 +52,15 @@ export class MemberController {
     description: '사용자 요약 정보',
     type: MemberSummaryResponseDto,
   })
+  @ApiQuery({ name: 'filter', description: 'ranking을 매기는 특정 기준', enum: Filter, example: Filter.COMMITDATE, required: true })
   @ApiBearerAuth('access-token')
   @UseGuards(AuthGuard('jwt'))
   @Get('/me')
   async getMemberByAccessToken(
+    @Query('filter', new DefaultValuePipe(Filter.COMMIT)) filter: string,
     @GetMember() member: Member,
   ): Promise<MemberSummaryResponseDto> {
-    return await this.memberService.getMemberSummary(member.id);
+    return await this.memberService.getMemberSummary(filter, member.id);
   }
 
   @ApiOperation({
@@ -73,8 +76,9 @@ export class MemberController {
   @Get('/:memberId')
   async getMemberSummary(
     @Param('memberId', ParseIntPipe) memberId: number,
+    @Query('filter', new DefaultValuePipe(Filter.COMMIT)) filter: Filter,
   ): Promise<MemberSummaryResponseDto> {
-    return await this.memberService.getMemberSummary(memberId);
+    return await this.memberService.getMemberSummary(filter, memberId);
   }
 
   @ApiOperation({

--- a/src/member/presentation/member.controller.ts
+++ b/src/member/presentation/member.controller.ts
@@ -57,10 +57,9 @@ export class MemberController {
   @UseGuards(AuthGuard('jwt'))
   @Get('/me')
   async getMemberByAccessToken(
-    @Query('filter', new DefaultValuePipe(Filter.COMMIT)) filter: string,
     @GetMember() member: Member,
   ): Promise<MemberSummaryResponseDto> {
-    return await this.memberService.getMemberSummary(filter, member.id);
+    return await this.memberService.getMemberSummary(member.id);
   }
 
   @ApiOperation({
@@ -76,9 +75,8 @@ export class MemberController {
   @Get('/:memberId')
   async getMemberSummary(
     @Param('memberId', ParseIntPipe) memberId: number,
-    @Query('filter', new DefaultValuePipe(Filter.COMMIT)) filter: Filter,
   ): Promise<MemberSummaryResponseDto> {
-    return await this.memberService.getMemberSummary(filter, memberId);
+    return await this.memberService.getMemberSummary(memberId);
   }
 
   @ApiOperation({

--- a/src/rank/application/dto/rank.dto.ts
+++ b/src/rank/application/dto/rank.dto.ts
@@ -35,3 +35,26 @@ export class RankDto {
   @IsString()
   upDown: string | null;
 }
+
+
+export class userRankDto {
+  @ApiProperty()
+  STAR: RankDto[];
+
+  @ApiProperty()
+  COMMIT: RankDto[];
+
+  @ApiProperty()
+  COMMITDATE: RankDto[];
+
+  @ApiProperty()
+  ARTICLECNT: RankDto[];
+}
+
+export class RankWithHostDto {
+  @ApiProperty()
+  hostRank: RankDto | null;
+  
+  @ApiProperty({type: [RankDto]})
+  rankData: RankDto[];
+}

--- a/src/rank/application/dto/rank.dto.ts
+++ b/src/rank/application/dto/rank.dto.ts
@@ -36,21 +36,6 @@ export class RankDto {
   upDown: string | null;
 }
 
-
-export class userRankDto {
-  @ApiProperty()
-  STAR: RankDto[];
-
-  @ApiProperty()
-  COMMIT: RankDto[];
-
-  @ApiProperty()
-  COMMITDATE: RankDto[];
-
-  @ApiProperty()
-  ARTICLECNT: RankDto[];
-}
-
 export class RankWithHostDto {
   @ApiProperty()
   hostRank: RankDto | null;

--- a/src/rank/application/log-data-cron.service.ts
+++ b/src/rank/application/log-data-cron.service.ts
@@ -63,7 +63,7 @@ export class LogDataCronService {
 
   @Cron('0 20 */2 * * *')
   public async collectNaverLog() {
-    console.log('batvch');
+    console.log('batch');
     const flatform = 'NAVER';
     const member = await this.memberRepository.getMembersWithBlogs(flatform);
     const logType = await this.dataLogTypeRepository.findOneLogType(

--- a/src/rank/application/log-data.service.ts
+++ b/src/rank/application/log-data.service.ts
@@ -4,7 +4,7 @@ import { Member } from 'src/member/domain/member.entity';
 import { LogDataRepository } from '../repository/log-data.repository';
 import { RankDataDto } from './dto/rank-log-data.dto';
 import { RankSearchDto } from './dto/rank-search.dto';
-import { RankDto } from './dto/rank.dto';
+import { RankDto, RankWithHostDto } from './dto/rank.dto';
 
 
 @Injectable()
@@ -14,10 +14,10 @@ export class LogDataService {
     private readonly logDataRepository: LogDataRepository,
   ) {}
 
-  public async getRank(rankDataDto: RankDataDto, member: Member): Promise<RankDto[]>  {
+  public async getRank(rankDataDto: RankDataDto, member: Member): Promise<RankWithHostDto>  {
     const rankData = await this.logDataRepository.getRankByLogData(rankDataDto, member);
 
-    return this.moveMemberToFirst(rankData, member.id);
+    return this.getHostRank(rankData, member.id);
   }
 
   public async getRankByKeaword(rankSearchDto: RankSearchDto, member: Member): Promise<RankDto[]>  {
@@ -32,15 +32,20 @@ export class LogDataService {
     return rankData;
   }
 
-  public moveMemberToFirst(rankData: RankDto[], memberId: number) {
+  public getHostRank(rankData: RankDto[], memberId: number) {
     const index = rankData.findIndex((item) => item.memberId === memberId);
 
     if (index === -1)
-      return rankData;
+      return {
+        hostRank: null,
+        rankData
+      };
 
     const item = rankData.splice(index, 1)[0];
-    rankData.unshift(item);
-
-    return rankData;
+    
+    return {
+      hostRank: item,
+      rankData
+    };
   }
 }

--- a/src/rank/application/log-data.service.ts
+++ b/src/rank/application/log-data.service.ts
@@ -26,6 +26,12 @@ export class LogDataService {
     return rankData;
   }
 
+  public async getRankWithNeighbors(filter: string, memberId: number): Promise<RankDto[]>  {
+    const rankData = await this.logDataRepository.getRankWithNeighbors(filter, memberId);
+
+    return rankData;
+  }
+
   public moveMemberToFirst(rankData: RankDto[], memberId: number) {
     const index = rankData.findIndex((item) => item.memberId === memberId);
 

--- a/src/rank/domain/filter.enum.ts
+++ b/src/rank/domain/filter.enum.ts
@@ -2,4 +2,5 @@ export enum Filter {
   STAR = 'STAR',
   COMMIT = 'COMMIT',
   COMMITDATE = 'COMMITDATE',
+  ARTICLECNT = 'ARTICLECNT',
 }

--- a/src/rank/presentation/rank.controller.ts
+++ b/src/rank/presentation/rank.controller.ts
@@ -6,7 +6,7 @@ import { ApiBearerAuth, ApiOkResponse, ApiOperation, ApiQuery, ApiTags } from '@
 import { GetMember } from 'src/auth/presentation/get-member.decorator';
 import { Member } from 'src/member/domain/member.entity';
 import { RankDataDto } from '../application/dto/rank-log-data.dto';
-import { RankDto } from '../application/dto/rank.dto';
+import { RankDto, RankWithHostDto } from '../application/dto/rank.dto';
 import { RankSearchDto } from '../application/dto/rank-search.dto';
 import { LogDataService } from '../application/log-data.service';
 import { Filter } from '../domain/filter.enum';
@@ -19,7 +19,7 @@ export class RankController {
   @ApiOperation({ summary: '특정 기준에 따른 user 랭킹 반환 API' })
   @ApiQuery({ name: 'filter', description: 'ranking을 매기는 특정 기준', enum: Filter, example: Filter.COMMITDATE, required: true })
   @ApiQuery({ name: 'page', description: '원하는 page의 값', type: Number, example: 1, required: true })
-  @ApiOkResponse({ type: [RankDto] })
+  @ApiOkResponse({ type: RankWithHostDto })
   @ApiBearerAuth('access-token')
   @UseGuards(AuthGuard('jwt'))
   @Get('')
@@ -27,7 +27,7 @@ export class RankController {
   public async getRankByFilter(
     @GetMember() member: Member,
     @Query() rankDataDto: RankDataDto,
-  ): Promise<RankDto[]>  {
+  ): Promise<RankWithHostDto>  {
     return await this.logDataService.getRank(rankDataDto, member);
   }
 

--- a/src/rank/repository/log-data.repository.ts
+++ b/src/rank/repository/log-data.repository.ts
@@ -161,4 +161,94 @@ export class LogDataRepository extends Repository<LogData> {
             })
             .sort(function(a, b){ return a.ranking-b.ranking; });
     }
+
+    public async getRankWithNeighbors(filter: string, memberId: number): Promise<RankDto[]> {
+        const results = await this.query(
+            `
+            select R1.memberId, R1.starId, R1.name, R1.profileImageUrl, R1.ranking, R1.dataLog, R1.logTypeId
+            from(
+            select today_rank.member_id as memberId,
+                s.id as starId,
+                m.name,
+                m.profile_image_url as profileImageUrl,
+                today_rank.ranking, 
+                today_rank.data_log as dataLog, 
+                today_rank.log_type_id as logTypeId,
+                CASE
+                        WHEN today_rank.ranking > yesterday_rank.ranking THEN 'up'
+                        WHEN today_rank.ranking < yesterday_rank.ranking THEN 'down'
+                        WHEN today_rank.ranking = yesterday_rank.ranking THEN 'unchanged'
+                        ELSE null
+                    END AS upDown
+                from (
+                    SELECT
+                    rank() over (order by max(data_log) desc) as ranking,
+                    max(ld.data_log) as data_log,
+                    ld.log_date,
+                    ld.member_id,
+                    ld.log_type_id
+                    FROM log_data as ld
+                    left join data_log_type as dlt
+                    on dlt.id = ld.log_type_id
+                    WHERE DATE(ld.log_date) >= DATE_FORMAT(NOW() ,'%Y-%m-01')
+                    AND dlt.log_type = '${filter}'
+                    group by ld.member_id, ld.member_id
+                    order by ranking asc, ld.member_id asc) as today_rank
+                left outer join (
+                    SELECT
+                    rank() over (order by max(data_log) desc) as ranking,
+                    max(ld.data_log) as data_log,
+                    ld.log_date,
+                    ld.member_id,
+                    ld.log_type_id
+                    FROM log_data as ld
+                    left join data_log_type as dlt
+                    on dlt.id = ld.log_type_id
+                    WHERE DATE(ld.log_date) BETWEEN DATE_FORMAT(NOW() - INTERVAL 1 MONTH ,'%Y-%m-01') AND DATE(NOW() - INTERVAL 1 DAY)
+                    AND dlt.log_type = '${filter}'
+                    group by ld.member_id, ld.member_id
+                ) as yesterday_rank
+                    on today_rank.member_id = yesterday_rank.member_id
+                left join member as m
+                    on today_rank.member_id = m.id
+                left join (
+                    select id, member_id, following_id from star
+                        where member_id = '${memberId}'
+                    ) as s
+                    on today_rank.member_id = s.following_id
+                ) as R1
+                left join(
+                    select today_rank.member_id as memberId,
+                        m.name,
+                        m.profile_image_url as profileImageUrl,
+                        today_rank.ranking 
+                        from (
+                            SELECT
+                            rank() over (order by max(data_log) desc) as ranking,
+                            max(ld.data_log) as data_log,
+                            ld.log_date,
+                            ld.member_id,
+                            ld.log_type_id
+                            FROM log_data as ld
+                            left join data_log_type as dlt
+                            on dlt.id = ld.log_type_id
+                            WHERE DATE(ld.log_date) >= DATE_FORMAT(NOW() ,'%Y-%m-01')
+                            AND dlt.log_type = 'COMMITDATE'
+                            group by ld.member_id, ld.member_id
+                            order by ranking asc, ld.member_id asc) as today_rank
+                        left join member as m
+                            on today_rank.member_id = m.id
+                        where today_rank.member_id = '${memberId}'
+                        ) as R2
+                        on R1.ranking <= R2.ranking + 1 and R1.ranking >= R2.ranking - 1
+                        where R2.ranking is not null`
+        );
+
+        return results
+            .map((rank) => {
+                rank.ranking = parseInt(rank.ranking);
+                return rank;
+            })
+            .sort(function(a, b){ return a.ranking-b.ranking; });
+    }
 }

--- a/src/rank/repository/log-data.repository.ts
+++ b/src/rank/repository/log-data.repository.ts
@@ -246,7 +246,7 @@ export class LogDataRepository extends Repository<LogData> {
                             left join data_log_type as dlt
                             on dlt.id = ld.log_type_id
                             WHERE DATE(ld.log_date) BETWEEN DATE_FORMAT(NOW() ,'%Y-%m-01') AND DATE(NOW())
-                            AND dlt.log_type = 'COMMITDATE'
+                            AND dlt.log_type = '${filter}'
                             group by ld.member_id, ld.member_id
                             order by ranking asc, ld.member_id asc) as today_rank
                         left join member as m

--- a/src/rank/repository/log-data.repository.ts
+++ b/src/rank/repository/log-data.repository.ts
@@ -33,6 +33,7 @@ export class LogDataRepository extends Repository<LogData> {
 
     public async getRankByLogData(rankDataDto: RankDataDto, member: Member): Promise<RankDto[]> {
         const { filter, page } = rankDataDto;
+        const aggregationFunction = filter === 'COMMITDATE' ? 'MAX' : 'SUM';
         const results = await this.query(
             `
             select today_rank.member_id as memberId,
@@ -50,8 +51,8 @@ export class LogDataRepository extends Repository<LogData> {
                     END AS upDown
                 from (
                     SELECT
-                    rank() over (order by max(data_log) desc) as ranking,
-                    max(ld.data_log) as data_log,
+                    rank() over (order by ${aggregationFunction}(data_log) desc) as ranking,
+                    ${aggregationFunction}(ld.data_log) as data_log,
                     ld.log_date,
                     ld.member_id,
                     ld.log_type_id
@@ -64,8 +65,8 @@ export class LogDataRepository extends Repository<LogData> {
                     order by ranking asc, ld.member_id asc) as today_rank
                 left outer join (
                     SELECT
-                    rank() over (order by max(data_log) desc) as ranking,
-                    max(ld.data_log) as data_log,
+                    rank() over (order by ${aggregationFunction}(data_log) desc) as ranking,
+                    ${aggregationFunction}(ld.data_log) as data_log,
                     ld.log_date,
                     ld.member_id,
                     ld.log_type_id
@@ -98,6 +99,8 @@ export class LogDataRepository extends Repository<LogData> {
 
     public async getRankByKeaword(rankSearchDto: RankSearchDto, member: Member): Promise<RankDto[]> {
         const { keyword, filter, page } = rankSearchDto;
+        const aggregationFunction = filter === 'COMMITDATE' ? 'MAX' : 'SUM';
+
         const results = await this.query(
             `
             select today_rank.member_id as memberId,
@@ -115,8 +118,8 @@ export class LogDataRepository extends Repository<LogData> {
                     END AS upDown
                 from (
                     SELECT
-                    rank() over (order by max(data_log) desc) as ranking,
-                    max(ld.data_log) as data_log,
+                    rank() over (order by ${aggregationFunction}(data_log) desc) as ranking,
+                    ${aggregationFunction}(ld.data_log) as data_log,
                     ld.log_date,
                     ld.member_id,
                     ld.log_type_id
@@ -129,8 +132,8 @@ export class LogDataRepository extends Repository<LogData> {
                     order by ranking asc, ld.member_id asc) as today_rank
                 left outer join (
                     SELECT
-                    rank() over (order by max(data_log) desc) as ranking,
-                    max(ld.data_log) as data_log,
+                    rank() over (order by ${aggregationFunction}(data_log) desc) as ranking,
+                    ${aggregationFunction}(ld.data_log) as data_log,
                     ld.log_date,
                     ld.member_id,
                     ld.log_type_id
@@ -163,6 +166,9 @@ export class LogDataRepository extends Repository<LogData> {
     }
 
     public async getRankWithNeighbors(filter: string, memberId: number): Promise<RankDto[]> {
+        const aggregationFunction = filter === 'COMMITDATE' ? 'MAX' : 'SUM';
+
+        
         const results = await this.query(
             `
             select R1.memberId, R1.starId, R1.name, R1.profileImageUrl, R1.ranking, R1.dataLog, R1.logTypeId
@@ -182,8 +188,8 @@ export class LogDataRepository extends Repository<LogData> {
                     END AS upDown
                 from (
                     SELECT
-                    rank() over (order by max(data_log) desc) as ranking,
-                    max(ld.data_log) as data_log,
+                    rank() over (order by ${aggregationFunction}(data_log) desc) as ranking,
+                    ${aggregationFunction}(ld.data_log) as data_log,
                     ld.log_date,
                     ld.member_id,
                     ld.log_type_id
@@ -196,8 +202,8 @@ export class LogDataRepository extends Repository<LogData> {
                     order by ranking asc, ld.member_id asc) as today_rank
                 left outer join (
                     SELECT
-                    rank() over (order by max(data_log) desc) as ranking,
-                    max(ld.data_log) as data_log,
+                    rank() over (order by ${aggregationFunction}(data_log) desc) as ranking,
+                    ${aggregationFunction}(ld.data_log) as data_log,
                     ld.log_date,
                     ld.member_id,
                     ld.log_type_id
@@ -224,8 +230,8 @@ export class LogDataRepository extends Repository<LogData> {
                         today_rank.ranking 
                         from (
                             SELECT
-                            rank() over (order by max(data_log) desc) as ranking,
-                            max(ld.data_log) as data_log,
+                            rank() over (order by ${aggregationFunction}(data_log) desc) as ranking,
+                            ${aggregationFunction}(ld.data_log) as data_log,
                             ld.log_date,
                             ld.member_id,
                             ld.log_type_id

--- a/src/rank/repository/log-data.repository.ts
+++ b/src/rank/repository/log-data.repository.ts
@@ -50,28 +50,32 @@ export class LogDataRepository extends Repository<LogData> {
                     END AS upDown
                 from (
                     SELECT
-                    rank() over (order by data_log desc) as ranking,
-                    ld.data_log,
+                    rank() over (order by max(data_log) desc) as ranking,
+                    max(ld.data_log) as data_log,
                     ld.log_date,
                     ld.member_id,
                     ld.log_type_id
                     FROM log_data as ld
                     left join data_log_type as dlt
                     on dlt.id = ld.log_type_id
-                    WHERE DATE(ld.log_date) = DATE(NOW()) AND dlt.log_type = '${filter}'
+                    WHERE DATE(ld.log_date) >= DATE_FORMAT(NOW() ,'%Y-%m-01')
+                    AND dlt.log_type = '${filter}'
+                    group by ld.member_id, ld.member_id
                     order by ranking asc, ld.member_id asc) as today_rank
                 left outer join (
                     SELECT
-                    rank() over (order by data_log desc) as ranking,
-                    ld.data_log,
+                    rank() over (order by max(data_log) desc) as ranking,
+                    max(ld.data_log) as data_log,
                     ld.log_date,
                     ld.member_id,
                     ld.log_type_id
                     FROM log_data as ld
                     left join data_log_type as dlt
                     on dlt.id = ld.log_type_id
-                    WHERE DATE(ld.log_date) = DATE(NOW() - INTERVAL 1 DAY) AND dlt.log_type = '${filter}'
-                ) as yesterday_rank
+                    WHERE DATE(ld.log_date) BETWEEN DATE_FORMAT(NOW() - INTERVAL 1 MONTH ,'%Y-%m-01') AND DATE(NOW() - INTERVAL 1 DAY)
+                    AND dlt.log_type = '${filter}'
+                    group by ld.member_id, ld.member_id
+                    ) as yesterday_rank
                     on today_rank.member_id = yesterday_rank.member_id
                 left join member as m
                     on today_rank.member_id = m.id
@@ -111,28 +115,32 @@ export class LogDataRepository extends Repository<LogData> {
                     END AS upDown
                 from (
                     SELECT
-                    rank() over (order by data_log desc) as ranking,
-                    ld.data_log,
+                    rank() over (order by max(data_log) desc) as ranking,
+                    max(ld.data_log) as data_log,
                     ld.log_date,
                     ld.member_id,
                     ld.log_type_id
                     FROM log_data as ld
                     left join data_log_type as dlt
                     on dlt.id = ld.log_type_id
-                    WHERE DATE(ld.log_date) = DATE(NOW()) AND dlt.log_type = '${filter}'
+                    WHERE DATE(ld.log_date) >= DATE_FORMAT(NOW() ,'%Y-%m-01')
+                    AND dlt.log_type = '${filter}'
+                    group by ld.member_id, ld.member_id
                     order by ranking asc, ld.member_id asc) as today_rank
                 left outer join (
                     SELECT
-                    rank() over (order by data_log desc) as ranking,
-                    ld.data_log,
+                    rank() over (order by max(data_log) desc) as ranking,
+                    max(ld.data_log) as data_log,
                     ld.log_date,
                     ld.member_id,
                     ld.log_type_id
                     FROM log_data as ld
                     left join data_log_type as dlt
                     on dlt.id = ld.log_type_id
-                    WHERE DATE(ld.log_date) = DATE(NOW() - INTERVAL 1 DAY) AND dlt.log_type = '${filter}'
-                ) as yesterday_rank
+                    WHERE DATE(ld.log_date) BETWEEN DATE_FORMAT(NOW() - INTERVAL 1 MONTH ,'%Y-%m-01') AND DATE(NOW() - INTERVAL 1 DAY)
+                    AND dlt.log_type = '${filter}'
+                    group by ld.member_id, ld.member_id
+                    ) as yesterday_rank
                     on today_rank.member_id = yesterday_rank.member_id
                 left join member as m
                     on today_rank.member_id = m.id


### PR DESCRIPTION
-  GET /member/me API 
- GET /member/{memberId} API
위 두 API에 랭킹 데이터 반환 로직 추가

추가로 
특정 기준에 따른 user 랭킹 반환 API - GET /rank 의 랭킹 구하는 쿼리문도 수정했습니다.
기존 오늘과 어제의 데이터만을 비교해 등락, 랭킹을 매기는 방식 -> 이번달안의 데이터 중 최대값을 기준으로 등락, 랭킹을 매기는 방식


resolved: #47 